### PR TITLE
Fix AttributeError: module 'collections' has no attribute 'Hashable'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dateutil>=2.8
 sqlalchemy>=1.3,<1.4
 pytz
 spacy>=3.5
+pyyaml>=6.0.1


### PR DESCRIPTION
Related to #3

Update the PyYAML version in `requirements.txt` to the latest version.

* Add `pyyaml>=6.0.1` to the `requirements.txt` file to resolve the AttributeError related to the 'collections' module's 'Hashable' attribute.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ShoneGK/ChatterPy/issues/3?shareId=e5e93726-0e46-47b6-9dbf-b53edc8f1d2d).